### PR TITLE
inherit default text-color

### DIFF
--- a/src/js/content_script.js
+++ b/src/js/content_script.js
@@ -109,7 +109,7 @@ blocklist.searchpage.insertAddBlockLinkInSearchResult = function (searchResult, 
   var insertLink = document.createElement('p');
   insertLink.innerHTML = chrome.i18n.getMessage("addBlocklist", hostlink);
   insertLink.style.cssText =
-    "color:#1a0dab;margin:0;text-decoration:underline;cursor: pointer;";
+    "margin:0;text-decoration:underline;cursor: pointer;";
   searchResult.appendChild(insertLink);
 
   insertLink.addEventListener("click", function () {


### PR DESCRIPTION
This solves the issue of the text being essentially unreadable if using a dark background theme on google